### PR TITLE
Adds support for multiple configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !index.js
 yarn.lock
 node_modules
+.yarn

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "babel-preset-gatsby-package": "^0.1.4",
+    "babel-preset-gatsby-package": "^0.3.0",
     "cross-env": "^5.1.4"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager#readme",
+  "homepage": "https://github.com/ironstar-io/gatsby-plugin-algolia-docsearch",
   "keywords": [
     "gatsby",
     "gatsby-plugin",
@@ -32,7 +32,7 @@
   "repository": "https://github.com/ironstar-io/gatsby-plugin-algolia-docsearch",
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
-    "prepare": "cross-env NODE_ENV=production npm run build",
+    "prepack": "cross-env NODE_ENV=production $npm_execpath run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   }
 }

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -3,9 +3,21 @@ import { stripIndent } from "common-tags";
 
 exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
-  { apiKey, indexName, inputSelector, debug = false }
+  configuration,
 ) => {
-  if (!apiKey || !indexName || !inputSelector) {
+  if (!configuration) {
+    return;
+  }
+
+  if (!Array.isArray(configuration)) {
+    configuration = [configuration];
+  }
+
+  configuration = configuration.filter(spec => {
+    return spec.apiKey && spec.indexName && spec.inputSelector;
+  });
+
+  if (configuration.length === 0) {
     return;
   }
 
@@ -23,34 +35,36 @@ exports.onRenderBody = (
       type="text/javascript"
       src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
     />,
-    <script
-      key="plugin-docsearch-initiate"
-      type="text/javascript"
-      dangerouslySetInnerHTML={{
-        __html: stripIndent`
-        var observer = new MutationObserver(function (mutations, instance) {
-          var docuSearchElem = document.querySelector('${inputSelector}');
-          if (docuSearchElem) {
-            docsearch({
-              apiKey: "${apiKey}",
-              indexName: "${indexName}",
-              inputSelector: "${inputSelector}",
-              debug: ${debug === true ? "true" : "false"}
-            });
-            instance.disconnect(); // stop observing
-            return;
-          }
-        });
-
-        // start observing
-        document.addEventListener("DOMContentLoaded", function() {
-          observer.observe(document, {
-            childList: true,
-            subtree: true
+    ...configuration.map(({ apiKey, indexName, inputSelector, debug = false }) => (
+      <script
+        key="plugin-docsearch-initiate"
+        type="text/javascript"
+        dangerouslySetInnerHTML={{
+          __html: stripIndent`
+          var observer = new MutationObserver(function (mutations, instance) {
+            var docuSearchElem = document.querySelector('${inputSelector}');
+            if (docuSearchElem) {
+              docsearch({
+                apiKey: "${apiKey}",
+                indexName: "${indexName}",
+                inputSelector: "${inputSelector}",
+                debug: ${debug === true ? "true" : "false"}
+              });
+              instance.disconnect(); // stop observing
+              return;
+            }
           });
-        });
-        `
-      }}
-    />
+
+          // start observing
+          document.addEventListener("DOMContentLoaded", function() {
+            observer.observe(document, {
+              childList: true,
+              subtree: true
+            });
+          });
+          `
+        }}
+      />
+    ),
   ]);
 };


### PR DESCRIPTION
I need to have multiple configurations, which isn't possible at the moment. This diff adds a syntax to pass an array of spec, while remaining compatible with the old style.